### PR TITLE
Prevent session nulling on timeout handling

### DIFF
--- a/python/the_judge/application/services/processing_service.py
+++ b/python/the_judge/application/services/processing_service.py
@@ -50,7 +50,8 @@ class FrameProcessingService:
             self.executor, self.process_frame, event.frame, str(image_path)
         )
 
-    def process_frame(self, frame: Frame, image_path: str) -> None:        
+    def process_frame(self, frame: Frame, image_path: str) -> None:
+        frame_id = frame.id
         try:
             image = self._load_image(image_path)
             if image is None:
@@ -72,8 +73,8 @@ class FrameProcessingService:
 
             self.tracking_service.handle_timeouts()
 
-        except Exception as exc:
-            logger.exception("Error processing frame %s", frame.id)
+        except Exception:
+            logger.exception("Error processing frame %s", frame_id)
 
     def _load_image(self, image_path: str):
         img = cv2.imread(image_path)

--- a/python/the_judge/infrastructure/db/orm.py
+++ b/python/the_judge/infrastructure/db/orm.py
@@ -93,11 +93,13 @@ def start_mappers():
     mapper_registry.map_imperatively(Frame, frames)
     mapper_registry.map_imperatively(FaceEmbedding, face_embeddings)
     mapper_registry.map_imperatively(Visitor, visitors, properties={
-        'current_session': relationship('VisitorSession', 
-                                       primaryjoin='and_(Visitor.id == VisitorSession.visitor_id, VisitorSession.ended_at == None)',
-                                       uselist=False,
-                                       lazy='select'
-                                       )
+        'current_session': relationship(
+            'VisitorSession',
+            primaryjoin='and_(Visitor.id == VisitorSession.visitor_id, VisitorSession.ended_at == None)',
+            uselist=False,
+            lazy='select',
+            viewonly=True,
+        )
     })
     
     mapper_registry.map_imperatively(Face, faces, properties={


### PR DESCRIPTION
## Summary
- mark Visitor.current_session relationship as view-only to stop SQLAlchemy from nulling visitor_id when a session is removed
- store frame id before processing so logging errors doesn't access detached objects

## Testing
- no tests run

------
https://chatgpt.com/codex/tasks/task_e_6890c6660b5083269fe5d52d41da3adb